### PR TITLE
Parameterized JMeter and Kafka dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
         <jdk.version>1.6</jdk.version>
+        <jmeter.version>2.11</jmeter.version>
+        <kafka.version>0.9.0.1</kafka.version>
     </properties>
 
     <dependencies>
@@ -45,7 +47,7 @@
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_core</artifactId>
-            <version>2.11</version>
+            <version>${jmeter.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -59,7 +61,7 @@
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_java</artifactId>
-            <version>2.11</version>
+            <version>${jmeter.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -75,7 +77,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.9.0.1</version>
+            <version>${kafka.version}</version>
             <exclusions>
                 <!-- XXX Transitively includes log4j 1.2.15 which has bad metadata
                      http://stackoverflow.com/a/9047963 -->


### PR DESCRIPTION
Changed the JMeter and Kafka dependency versions values to properties for easy switching among the Kafka and JMeter versions.